### PR TITLE
[refactor] 하루기록 페이지 스타일 하드코딩 정리 및 홈 화면 톤 통일

### DIFF
--- a/DUNOESANCHAEG-Client/src/components/daily-record/RecordSection.vue
+++ b/DUNOESANCHAEG-Client/src/components/daily-record/RecordSection.vue
@@ -56,22 +56,23 @@
 
     <style scoped>
     .record-card {
-    background: #fff;
-    border-radius: 18px;
+    background: var(--color-surface);
+    border-radius: var(--radius-card);
     padding: 20px;
-    border: 1px solid #e5e7eb;
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--color-surface-variant);
+    box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
     }
 
     .record-title {
     margin: 0 0 14px;
-    font-size: 20px;
+    font-size: var(--text-xl);
     font-weight: 700;
-    color: #1f2937;
+    color: var(--color-text-main);
+    line-height: var(--text-xl--line-height);
     }
 
     .required {
-    color: #2563eb;
+    color: var(--color-brand-green);
     }
 
     .level-options {
@@ -83,28 +84,38 @@
     .level-btn {
     flex: 1;
     min-height: 52px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--color-surface-variant);
     border-radius: 14px;
-    background: #f8fafc;
-    font-size: 16px;
+    background: var(--color-brand-blue);
+    color: var(--color-text-sub);
+    font-size: var(--text-base);
     font-weight: 700;
     cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
     }
 
     .level-btn.active {
-    background: #dbeafe;
-    border-color: #2563eb;
-    color: #1d4ed8;
+    background: var(--color-brand-green);
+    border-color: var(--color-brand-green);
+    color: #ffffff;
+    transform: translateY(-1px);
     }
 
     .memo-textarea {
     width: 100%;
     min-height: 90px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--color-surface-variant);
     border-radius: 14px;
     padding: 12px;
     box-sizing: border-box;
     resize: vertical;
-    font-size: 15px;
+    background: var(--color-surface);
+    color: var(--color-text-main);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    }
+
+    .memo-textarea::placeholder {
+    color: var(--color-text-muted);
     }
 </style>

--- a/DUNOESANCHAEG-Client/src/pages/daily-record/DailyRecordPage.vue
+++ b/DUNOESANCHAEG-Client/src/pages/daily-record/DailyRecordPage.vue
@@ -145,11 +145,7 @@ const goHome = () => {
 .page-inner {
     max-width: 760px;
     margin: 0 auto;
-    padding: 28px 24px 32px;
-    background: var(--color-brand-blue);
-    border: 1px solid var(--color-surface-variant);
-    border-radius: var(--radius-card);
-    box-shadow: 0 8px 24px rgba(17, 24, 39, 0.06);
+    padding: 8px 0 0;
 }
 
 .page-header {
@@ -264,8 +260,7 @@ const goHome = () => {
 
 @media (max-width: 640px) {
     .page-inner {
-        padding: 24px 16px 28px;
-        border-radius: 1.5rem;
+        padding: 8px 0 0;
     }
 
     .page-title {

--- a/DUNOESANCHAEG-Client/src/pages/daily-record/DailyRecordPage.vue
+++ b/DUNOESANCHAEG-Client/src/pages/daily-record/DailyRecordPage.vue
@@ -3,91 +3,91 @@
         <div class="page-inner">
             <template v-if="!isSubmitted">
                 <div class="page-header">
-                    <button class="exit-btn" @click="goHome">나가기</button>
+                    <button class="exit-btn" type="button" @click="goHome" aria-label="홈으로 돌아가기">
+                        <van-icon name="arrow-left" size="18" />
+                    </button>
                 </div>
 
                 <h1 class="page-title">하루 기록</h1>
                 <p class="page-subtitle">오늘 하루 상태를 간단하게 기록해보세요.</p>
 
                 <p v-if="errorMessage" class="error-message">
-                {{ errorMessage }}
+                    {{ errorMessage }}
                 </p>
 
-        <div class="record-list">
-            <RecordSection
-            title="오늘 기분은 어떠셨나요?"
-            :required="true"
-            v-model:selectedLevel="form.moodLevel"
-            v-model:memo="form.moodMemo"
-            placeholder="예시) 오늘은 날씨가 좋아서 기분도 좋았어요."
-            />
+                <div class="record-list">
+                    <RecordSection
+                        title="오늘 기분은 어떠셨나요?"
+                        :required="true"
+                        v-model:selectedLevel="form.moodLevel"
+                        v-model:memo="form.moodMemo"
+                        placeholder="예시) 오늘은 산책가 좋아서 기분이 좋았어요."
+                    />
 
-            <RecordSection
-            title="잠은 잘 주무셨나요?"
-            :required="true"
-            v-model:selectedLevel="form.sleepLevel"
-            v-model:memo="form.sleepMemo"
-            placeholder="예시) 중간에 한 번 깨긴 했지만 괜찮았어요."
-            />
+                    <RecordSection
+                        title="어제 잘 주무셨나요?"
+                        :required="true"
+                        v-model:selectedLevel="form.sleepLevel"
+                        v-model:memo="form.sleepMemo"
+                        placeholder="예시) 중간중간 몇 번 깼지만 괜찮았어요."
+                    />
 
-            <RecordSection
-            title="식사는 잘 챙겨드셨나요?"
-            :required="true"
-            v-model:selectedLevel="form.mealLevel"
-            v-model:memo="form.mealMemo"
-            placeholder="예시) 아침은 못 먹고 점심, 저녁은 잘 먹었어요."
-            />
+                    <RecordSection
+                        title="식사는 잘 챙겨드셨어요?"
+                        :required="true"
+                        v-model:selectedLevel="form.mealLevel"
+                        v-model:memo="form.mealMemo"
+                        placeholder="예시) 아침은 못 먹고 점심, 저녁은 잘 먹었어요."
+                    />
 
-            <RecordSection
-            title="몸을 움직이는 활동은 어떠셨나요?"
-            v-model:selectedLevel="form.exerciseLevel"
-            v-model:memo="form.exerciseMemo"
-            placeholder="예시) 산책을 조금 했어요."
-            />
+                    <RecordSection
+                        title="몸을 움직이거나 활동은 어떠셨나요?"
+                        v-model:selectedLevel="form.exerciseLevel"
+                        v-model:memo="form.exerciseMemo"
+                        placeholder="예시) 산책을 조금 했어요."
+                    />
 
-            <RecordSection
-            title="다른 사람들과의 만남이나 활동은 어떠셨나요?"
-            v-model:selectedLevel="form.socialLevel"
-            v-model:memo="form.socialMemo"
-            placeholder="예시) 가족과 통화해서 기분이 좋았어요."
-            />
-        </div>
+                    <RecordSection
+                        title="다른 사람과의 만남이나 소통은 어떠셨나요?"
+                        v-model:selectedLevel="form.socialLevel"
+                        v-model:memo="form.socialMemo"
+                        placeholder="예시) 가족과 통화해서 기분이 좋아졌어요."
+                    />
+                </div>
 
-        <button class="submit-btn" @click="handleSubmit">
-            저장하기
-        </button>
-    </template>
-
-    <template v-else>
-        <div class="complete-wrap">
-            <div class="complete-icon">✅</div>
-            <h1 class="complete-title">하루기록 등록이 완료되었습니다!</h1>
-            <p class="complete-subtitle">
-                오늘의 하루를 잘 기록했어요.<br />
-                남은 루틴도 이어서 수행해보세요.
-            </p>
-
-            <div class="complete-button-group">
-                <button :style="homeButtonStyle" @click="goHome">
-                홈화면으로 가기
+                <button class="submit-btn" @click="handleSubmit">
+                    저장하기
                 </button>
-            </div>
-            </div>
-        </template>
+            </template>
 
+            <template v-else>
+                <div class="complete-wrap">
+                    <div class="complete-icon">😊</div>
+                    <h1 class="complete-title">하루기록 등록이 완료되었습니다</h1>
+                    <p class="complete-subtitle">
+                        오늘의 하루를 잘 기록했어요.<br />
+                        다음 루틴도 이어서 수행해보세요.
+                    </p>
+
+                    <div class="complete-button-group">
+                        <button class="home-btn" @click="goHome">
+                            홈화면으로 가기
+                        </button>
+                    </div>
+                </div>
+            </template>
         </div>
     </div>
-    </template>
+</template>
 
-    <script setup>
-    import { reactive, ref } from 'vue';
-    import { useRouter } from 'vue-router';
-    import RecordSection from '@/components/daily-record/RecordSection.vue';
-    import { computed } from 'vue';
+<script setup>
+import { reactive, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import RecordSection from '@/components/daily-record/RecordSection.vue';
 
-    const router = useRouter();
+const router = useRouter();
 
-    const form = reactive({
+const form = reactive({
     moodLevel: '',
     moodMemo: '',
     sleepLevel: '',
@@ -98,17 +98,17 @@
     exerciseMemo: '',
     socialLevel: '',
     socialMemo: '',
-    });
+});
 
-    const errorMessage = ref('');
-    const isSubmitted = ref(false);
+const errorMessage = ref('');
+const isSubmitted = ref(false);
 
-    const handleSubmit = () => {
+const handleSubmit = () => {
     alert('오늘의 하루기록을 저장하시겠습니까?');
 
-        errorMessage.value = '';
+    errorMessage.value = '';
 
-        if (!form.moodLevel) {
+    if (!form.moodLevel) {
         errorMessage.value = '기분 항목은 필수로 선택해야 해요.';
         return;
     }
@@ -125,123 +125,152 @@
 
     console.log('현재 form 상태:', JSON.parse(JSON.stringify(form)));
     isSubmitted.value = true;
-    };
+};
 
-    const goHome = () => {
+const goHome = () => {
     router.push('/');
 };
-const homeButtonStyle = computed(() => ({
-  width: '220px',
-  height: '52px',
-  border: 'none',
-  borderRadius: '16px',
-  background: 'var(--color-brand-green)',
-  color: '#fff',
-  fontSize: 'var(--text-base)',
-  fontWeight: 700,
-  cursor: 'pointer',
-  marginTop: '28px',
-}));
-    </script>
+</script>
 
-    <style scoped>
-    .daily-record-page {
+<style scoped>
+.daily-record-page {
+    --daily-record-error-bg: #fef2f2;
+    --daily-record-error-border: #fecaca;
+    --daily-record-error-text: #b91c1c;
     min-height: 100vh;
-    background: #f3f7fb;
+    background: var(--color-brand-bg);
     padding: 24px 16px 40px;
-    }
+}
 
-    .page-inner {
+.page-inner {
     max-width: 760px;
     margin: 0 auto;
-    }
+    padding: 28px 24px 32px;
+    background: var(--color-brand-blue);
+    border: 1px solid var(--color-surface-variant);
+    border-radius: var(--radius-card);
+    box-shadow: 0 8px 24px rgba(17, 24, 39, 0.06);
+}
 
-    .page-header {
+.page-header {
     display: flex;
     justify-content: flex-start;
     margin-bottom: 16px;
-    }
+}
 
-    .exit-btn {
-    min-width: 88px;
-    height: 42px;
-    border: 1px solid #cbd5e1;
-    border-radius: 12px;
-    background: #ffffff;
-    color: #334155;
-    font-size: 15px;
-    font-weight: 700;
+.exit-btn {
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-surface-variant);
+    border-radius: 9999px;
+    background: var(--color-surface);
+    color: var(--color-text-sub);
+    font-size: var(--text-sm);
     cursor: pointer;
-    }
+    box-shadow: 0 4px 10px rgba(17, 24, 39, 0.04);
+}
 
-    .page-title {
+.page-title {
     margin: 0;
-    font-size: 32px;
+    font-size: var(--text-3xl);
     font-weight: 800;
-    color: #2D7A36;
-    }
+    color: var(--color-brand-green);
+    line-height: var(--text-3xl--line-height);
+}
 
-    .page-subtitle {
+.page-subtitle {
     margin: 8px 0 20px;
-    font-size: 16px;
-    color: #6b7280;
-    }
+    font-size: var(--text-base);
+    color: var(--color-text-muted);
+    line-height: var(--text-base--line-height);
+}
 
-    .error-message {
+.error-message {
     margin: 0 0 16px;
     padding: 14px 16px;
     border-radius: 14px;
-    background: #fef2f2;
-    border: 1px solid #fecaca;
-    color: #b91c1c;
-    font-size: 15px;
+    background: var(--daily-record-error-bg);
+    border: 1px solid var(--daily-record-error-border);
+    color: var(--daily-record-error-text);
+    font-size: var(--text-sm);
     font-weight: 700;
 }
 
-    .record-list {
+.record-list {
     display: flex;
     flex-direction: column;
     gap: 16px;
-    }
+}
 
-    .submit-btn {
+.submit-btn {
     width: 100%;
     margin-top: 20px;
     min-height: 56px;
     border: none;
     border-radius: 16px;
-    background: #18860c;
-    color: #fff;
-    font-size: 17px;
+    background: var(--color-brand-green);
+    color: #ffffff;
+    font-size: var(--text-lg);
     font-weight: 800;
     cursor: pointer;
-    }
+    box-shadow: 0 10px 18px rgba(45, 122, 54, 0.2);
+}
 
-    .complete-wrap {
+.home-btn {
+    width: 220px;
+    height: 52px;
+    border: none;
+    border-radius: 16px;
+    background: var(--color-brand-green);
+    color: #ffffff;
+    font-size: var(--text-base);
+    font-weight: 700;
+    cursor: pointer;
+    margin-top: 28px;
+    box-shadow: 0 10px 18px rgba(45, 122, 54, 0.2);
+}
+
+.complete-wrap {
     min-height: 70vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     text-align: center;
-    }
+}
 
-    .complete-icon {
-    font-size: 56px;
+.complete-icon {
+    font-size: var(--text-6xl);
     margin-bottom: 18px;
+}
+
+.complete-title {
+    margin: 0;
+    font-size: var(--text-2xl);
+    font-weight: 800;
+    color: var(--color-brand-green);
+    line-height: var(--text-2xl--line-height);
+}
+
+.complete-subtitle {
+    margin: 12px 0 0;
+    font-size: var(--text-base);
+    color: var(--color-text-muted);
+    line-height: var(--text-base--line-height);
+}
+
+@media (max-width: 640px) {
+    .page-inner {
+        padding: 24px 16px 28px;
+        border-radius: 1.5rem;
     }
 
-    .complete-wrap {
-    min-height: 70vh;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
+    .page-title {
+        font-size: var(--text-2xl);
+        line-height: var(--text-2xl--line-height);
     }
-
-    .complete-icon {
-    font-size: 56px;
-    margin-bottom: 18px;
-    }
+}
 </style>


### PR DESCRIPTION
[refactor] 하루기록 페이지 스타일 하드코딩 정리 및 홈 화면 톤 통일
 
## 🔎개요 
하루기록 페이지 스타일 구조를 정리하고 홈 화면과 디자인 톤을 통일했습니다.
공통 토큰 기반으로 색상과 글자 크기 체계를 맞추고, 버튼과 카드 UI를 더 자연스럽게 다듬었습니다.
 
 
<br/>
 
## 📝작업 내용
 - 하루기록 페이지의 스타일 구조를 공통 토큰/변수 기반으로 정리해, 이후 글자 크기·색상·접근성 대응이 쉽도록 개선했습니다.
- 배경, 제목, 버튼, 카드 UI를 홈 화면과 같은 톤으로 맞춰 전체 디자인 일관성을 높였습니다.
- 기존의 텍스트형 나가기 버튼은 뒤로가기 아이콘 버튼으로 변경해 헤더가 더 자연스럽게 보이도록 조정했습니다.
 
<br/>
 
 
## 📸UI 스크린샷
<img width="466" height="797" alt="image" src="https://github.com/user-attachments/assets/e8ef6fb7-4aea-4a72-8827-d73e22e5631f" />
<img width="464" height="795" alt="image" src="https://github.com/user-attachments/assets/2cc0dff7-4e8a-4fc6-af3e-10b13b7fea7d" />

 
 
<br/>
 
