### PR TITLE
[refactor] 백엔드 로그아웃 API 연결 및 카카오 로그인 수정

### DIFF
--- a/DUNOESANCHAEG-Client/src/pages/login/KakaoCallback.vue
+++ b/DUNOESANCHAEG-Client/src/pages/login/KakaoCallback.vue
@@ -40,6 +40,9 @@ onMounted(async () => {
 
   console.log("카카오 인가 코드 확인됨");
 
+  authStore.logout(); // Pinia 스토어 및 localStorage 초기화
+  delete instance.defaults.headers.common['Authorization']; // Axios 글로벌 헤더 초기화
+
   try {
     // 1. 백엔드에 인가 코드 전달 및 토큰 발급 요청
     const response = await instance.post('/auth/kakao-auth', { code });

--- a/DUNOESANCHAEG-Client/src/pages/profile/Profile.vue
+++ b/DUNOESANCHAEG-Client/src/pages/profile/Profile.vue
@@ -172,10 +172,23 @@ const handleLogout = async () => {
     title: '로그아웃',
     message: '정말 로그아웃 하시겠습니까?',
   }).then(async () => {
-    authStore.logout();
-    await router.push('/login');
-    showToast('로그아웃 되었습니다.');
-  }).catch(() => {});
+    try {
+      // 1. 백엔드에 로그아웃 요청 (브라우저의 Refresh Token 쿠키 삭제)
+      await instance.post('/auth/logout');
+    } catch (error) {
+      console.error('서버 로그아웃 처리 중 오류:', error);
+      // 서버 오류가 발생하더라도 프론트엔드 데이터는 무조건 지워야 하므로 throw하지 않습니다.
+    } finally {
+      // 2. 프론트엔드 상태 및 로컬 스토리지 초기화 (Access Token 삭제)
+      authStore.logout();
+      showToast('로그아웃 되었습니다.');
+
+      // 3. 로그인 페이지로 이동 (히스토리에 남지 않도록 replace 사용)
+      await router.replace('/home');
+    }
+  }).catch(() => {
+    // 취소 버튼 클릭 시 실행됨
+  });
 };
 
 // 회원 탈퇴

--- a/DUNOESANCHAEG-Client/vite.config.js
+++ b/DUNOESANCHAEG-Client/vite.config.js
@@ -18,16 +18,16 @@ export default defineConfig(({ mode }) => {
         '@': fileURLToPath(new URL('./src', import.meta.url))
       }
     },
-    // server: {
-    //   proxy: {
-    //     '/api': {
-    //       target: env.VITE_PROXY_TARGET,
-    //       changeOrigin: true,
-    //       secure: false,
-    //       rewrite: (path) => path
-    //     }
-    //   }
-    // },
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_PROXY_TARGET,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path
+        }
+      }
+    },
     build: {
       target: 'esnext'
     }


### PR DESCRIPTION
… 삭제하도록 수정

<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->
 
## 🔎개요 
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
 -백엔드 로그아웃 API 연결 
 - 카카오 로그인시 기존 accessToken 피니아, 로컬스토리지에서 삭제되도록 변경
 
<br/>
## 👀변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
 - vite_config.js 주석 제거
 
 
<br/>